### PR TITLE
Generated GIF file is incomplete

### DIFF
--- a/src/gil/core.clj
+++ b/src/gil/core.clj
@@ -101,7 +101,9 @@
 (defn clean-up []
   (reset! metadata nil)
   (reset! param nil)
-  (.dispose @writer))
+  (.endWriteSequence @writer)
+  (.dispose @writer)
+  (reset! writer nil))
 
 ; TODO: capture frame-count once into local variable
 (defn save-animation [filename loop-count delay-time]


### PR DESCRIPTION
Header of the generated GIF file is incomplete, and some applications such as Photoshop cannot open it.
This PR is a patch to fix the problem by invoking endWriteSequence in clean-up function.

http://docs.oracle.com/javase/7/docs/api/javax/imageio/ImageWriter.html#endWriteSequence()
